### PR TITLE
Module: Abstract out the framework

### DIFF
--- a/natural_frontend/constants.py
+++ b/natural_frontend/constants.py
@@ -1,0 +1,7 @@
+FAST_API = "FastAPI"
+
+FAST_API_ROUTE_TYPE = "APIRoute"
+
+BAD_ROUTES_BY_FRAMEWORK = {
+    FAST_API: ["handle_form", "frontend"]
+}

--- a/natural_frontend/helpers.py
+++ b/natural_frontend/helpers.py
@@ -2,6 +2,12 @@ from collections.abc import Callable
 import inspect
 from typing import Any
 
+from .constants import FAST_API, FAST_API_ROUTE_TYPE, BAD_ROUTES_BY_FRAMEWORK
+
+class Route:
+    def __init__(self, code: str):
+        self.code = code
+
 
 def create_api_short_documentation_prompt(routes_code: str):
     return [
@@ -17,13 +23,33 @@ def create_api_short_documentation_prompt(routes_code: str):
     ]
 
 
-# TODO: Make route a Struct with just a "code" member to be framework-agnostic
-def aggregate_all_api_routes(routes: list[Any], exclude_route: Callable[[Any], bool]):
+def aggregate_all_api_routes(app: Any, framework_name: str):
+    if framework_name == FAST_API:
+        routes = app.routes
+    else:
+        raise ValueError("Framework not supported")
+    
     concat_sources = []
     for route in routes:
-        if not exclude_route(route):
-            concat_sources.append(inspect.getsource(route.endpoint))
+        clean_route = convert_and_filter_route_by_framework(route, framework_name)
+        if clean_route is not None:
+            concat_sources.append(inspect.getsource(clean_route.code))
 
     concat_sources = "\n\n".join(concat_sources)
 
     return concat_sources
+
+def convert_and_filter_route_by_framework(route: Any, framework_name: str) -> Route:
+    if framework_name == FAST_API:
+        if not route.__class__.__name__ == FAST_API_ROUTE_TYPE or route.endpoint.__name__ in BAD_ROUTES_BY_FRAMEWORK[framework_name]:
+            return None
+        return Route(route.endpoint)
+    else:
+        raise ValueError("Framework not supported")
+
+def get_framework_name_or_crash(app: Any) -> str :
+    if app.__class__.__name__ == FAST_API:
+        return FAST_API
+    else:
+        raise ValueError("Framework not supported")
+    


### PR DESCRIPTION
## Feature

This is the first step towards integrating new frameworks
This removes the assumption that the `app` object comes from FastAPI and implement a (proto) framework-agnostic logic
This includes:
- Scanning for endpoints source codes
- Adding routes to the router
- Figuring out how to do stuff overall when we don't know the app *a priori*

## TODOs

- [ ]  Figure out how to remove the trigger `@app.on_event("startup")`, which is annoying both because it's a **decorator** (not easy to modularize in an `if ...` statement) and because the `startup` event is specific to FastAPI (it's deprecated anyway --> https://fastapi.tiangolo.com/advanced/events/)

## How to test

We don't have a CI yet but the easiest way to test this is to:

- `python -m build`
- `cd examples/social_network`
- Make sure you don't have any local version of the package already installed, then `pip install ../../dist/{the_wheel_file}.whl`
- Then run it `python -m uvicorn main:app`